### PR TITLE
Jjs unique hostnames

### DIFF
--- a/custom/base/init.sls
+++ b/custom/base/init.sls
@@ -48,3 +48,10 @@ ferm:
     - watch:
       - pkg: ferm
       - file: /etc/ferm/ferm.conf
+
+system:
+  network.system:
+  - enabled: True
+  - hostname: {{ pillar.get('hostname') }}.{{ pillar.get('domain') }}
+  - nisdomain: {{ pillar.get('domain') }}
+  - apply_hostname: True

--- a/custom/base/init.sls
+++ b/custom/base/init.sls
@@ -55,3 +55,4 @@ system:
   - hostname: {{ pillar.get('hostname') }}.{{ pillar.get('domain') }}
   - nisdomain: {{ pillar.get('domain') }}
   - apply_hostname: True
+  - retain_settings: True

--- a/custom/compute/slurm.conf
+++ b/custom/compute/slurm.conf
@@ -1,4 +1,4 @@
-ControlMachine=packer-Ubuntu-18
+ControlMachine=hackathon
 AuthType=auth/munge
 CacheGroups=0
 CryptoType=crypto/munge
@@ -35,5 +35,5 @@ SlurmctldLogFile=/var/log/slurm-llnl/slurmctld.log
 SlurmdDebug=3
 SlurmdLogFile=/var/log/slurm-llnl/slurmd.log
 DefMemPerNode=10240
-NodeName=packer-Ubuntu-18 CPUs=4 RealMemory=10240 TmpDisk=8192 State=UNKNOWN
-PartitionName=debug Nodes=packer-Ubuntu-18 Default=YES MaxTime=INFINITE State=UP
+NodeName=hackathon CPUs=4 RealMemory=10240 TmpDisk=8192 State=UNKNOWN
+PartitionName=debug Nodes=hackathon Default=YES MaxTime=INFINITE State=UP

--- a/pillar/common.sls
+++ b/pillar/common.sls
@@ -1,2 +1,5 @@
 {% set domain = 'covid19workflows-vu.surf-hosted.nl' %}
 {% set contact_email = 'michael.crusoe@vu.nl ' %}
+
+hostname: packer-Ubuntu-18
+domain: covid19workflows-vu.surf-hosted.nl

--- a/pillar/hosts/compute0.sls
+++ b/pillar/hosts/compute0.sls
@@ -1,0 +1,1 @@
+hostname: compute0

--- a/pillar/hosts/compute1.sls
+++ b/pillar/hosts/compute1.sls
@@ -1,0 +1,1 @@
+hostname: compute1

--- a/pillar/hosts/hackathon.sls
+++ b/pillar/hosts/hackathon.sls
@@ -1,0 +1,1 @@
+hostname: hackathon

--- a/pillar/hosts/keep0.sls
+++ b/pillar/hosts/keep0.sls
@@ -1,0 +1,1 @@
+hostname: keep0

--- a/pillar/hosts/keep0.sls
+++ b/pillar/hosts/keep0.sls
@@ -1,1 +1,1 @@
-hostname: keep0
+hostname: keepstore0

--- a/pillar/hosts/keep1.sls
+++ b/pillar/hosts/keep1.sls
@@ -1,0 +1,1 @@
+hostname: keep1

--- a/pillar/hosts/keep1.sls
+++ b/pillar/hosts/keep1.sls
@@ -1,1 +1,1 @@
-hostname: keep1
+hostname: keepstore1

--- a/pillar/hosts/workbench
+++ b/pillar/hosts/workbench
@@ -1,0 +1,1 @@
+hostname: workbench

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -2,6 +2,7 @@ base:
   '*':
     - letsencrypt
     - google_oauth
+    - common
   'hackathon':
     - postgresql
     - nginx
@@ -9,11 +10,13 @@ base:
     - nginx_arvados_api
     - nginx_arvados_controller
     - letsencrypt_controller
+    - hosts/hackathon
   'workbench':
     - nginx
     - nginx_workbench
     - arvados
     - letsencrypt_workbench
+    - hosts/workbench
   'collections':
     - nginx
     - nginx_keepweb
@@ -21,3 +24,7 @@ base:
     - letsencrypt_keepweb
   'keep*':
     - arvados
+  'keep0':
+    - hosts/keep0
+  'keep1':
+    - hosts/keep1


### PR DESCRIPTION
Provide unique hostnames to hosts in the arvados cluster.
This is required in order to configure the slurm cluster in a multinode setup.

The mechanism is similar to Puppet's FQDN Hiera level.
This does not work well when infrastructure becomes dynamic and hostnames need to be generated.
To solve that now, however, would be premature.